### PR TITLE
Create log stream when push fails due to missing log stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A simple Log4J appender intended for use in Java EE environment</description>
-  <url>http://www.hextremelabs.com/</url>
+  <url>https://www.hextremelabs.com/</url>
 
   <licenses>
     <license>
       <name>Apache License 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 
@@ -29,7 +29,7 @@
       <name>Sayo Oladeji</name>
       <email>oluwasayo@hextremelabs.com</email>
       <organization>Hextremelabs</organization>
-      <organizationUrl>http://www.hextremelabs.com</organizationUrl>
+      <organizationUrl>https://www.hextremelabs.com</organizationUrl>
     </developer>
   </developers>
 
@@ -90,30 +90,32 @@
       <version>8.0.1</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>cloudwatchlogs</artifactId>
-      <version>2.17.148</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.hextremelabs</groupId>
-      <artifactId>quickee</artifactId>
-      <version>2.0.19</version>
-      <scope>provided</scope>
-    </dependency>
+    <!-- This is not vulnerable as mis-reported by tools as it's provided-scoped -->
+    <!-- Pinned to this version as it's what WildFly supports, see why https://stackoverflow.com/a/70332538 -->
+   <dependency>
+     <groupId>log4j</groupId>
+     <artifactId>log4j</artifactId>
+     <version>1.2.17</version>
+     <scope>provided</scope>
+   </dependency>
+   <dependency>
+     <groupId>software.amazon.awssdk</groupId>
+     <artifactId>cloudwatchlogs</artifactId>
+     <version>2.17.165</version>
+     <scope>provided</scope>
+   </dependency>
+   <dependency>
+     <groupId>com.hextremelabs</groupId>
+     <artifactId>quickee</artifactId>
+     <version>2.0.21</version>
+     <scope>provided</scope>
+   </dependency>
 
-    <!--Test Scope-->
+   <!--Test Scope-->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.7.0</version>
+      <version>5.8.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/hextremelabs/cloudwatchappender/CloudWatchHandler.java
+++ b/src/main/java/com/hextremelabs/cloudwatchappender/CloudWatchHandler.java
@@ -179,10 +179,10 @@ public class CloudWatchHandler {
     try {
       nextSequenceToken = client.putLogEvents(request).nextSequenceToken();
     } catch (InvalidSequenceTokenException | ResourceNotFoundException ex) {
-      // ResourceNotFoundException: If the Java application process is running on a different timezone than UTC (AWS),
-      // there would be a window of time when computeAwsLogStreamName() would return a log stream name that does not
-      // exist (i.e. when either of AWS or Java moves to a new day before the other as the date is part of the log
-      // stream name). This is fine.
+      // ResourceNotFoundException: If the JVM process is running on a different timezone than UTC (AWS), there would
+      // be a window of time when computeAwsLogStreamName() would return a log stream name that does not exist (i.e.
+      // when either of AWS or Java moves to a new day before the other as the date is part of the log stream name).
+      // This is okay.
 
       // InvalidSequenceTokenException: For whatever reason we have messed up the sequence token. This is fine if it's
       // a one-off event. If it keeps reoccurring then we have an extremely rare concurrency issue where this singleton


### PR DESCRIPTION
When we move to a new day and the log stream for the day is not yet created, we get a `ResourceNotFoundException`. There is a daily schedule that creates the log stream for the day at 12 midnight but since logs are published every 7 seconds, there is a 7-second window in which it's possible that the log stream for the day would not yet have been created by the time the schedule runs.

Solution
---
1. Drop the daily log stream creation schedule
2. When publishing logs, detect cases when the log stream doesn't exist yet and create it at that point, then republish the logs.